### PR TITLE
Fix: Property 'mockReturnValue' does not exist on type ...

### DIFF
--- a/src/Mock.spec.ts
+++ b/src/Mock.spec.ts
@@ -633,7 +633,8 @@ describe('vitest-mock-extended', () => {
   describe('mock Date', () => {
     test('should call built-in date functions', () => {
       type objWithDate = { date: Date }
-      const mockObj = mock<objWithDate>({ date: new Date('2000-01-15') })
+      const unixTimestamp = 947980800000 // Jan 15, 2000 at midnight UTC
+      const mockObj = mock<objWithDate>({ date: new Date(unixTimestamp) })
       expect(mockObj.date.getFullYear()).toBe(2000)
       expect(mockObj.date.getMonth()).toBe(0)
       expect(mockObj.date.getDate()).toBe(15)

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -1,5 +1,6 @@
 import { calledWithFn } from './CalledWithFn'
 import { MatchersOrLiterals } from './Matchers'
+import { FallbackImplementation } from './types'
 import { DeepPartial } from 'ts-essentials'
 import { Mock, vi } from 'vitest'
 
@@ -27,8 +28,8 @@ const VitestMockExtended = {
   },
 }
 
-interface CalledWithMock<T, Y extends any[]> extends Mock<Y, T> {
-  calledWith: (...args: Y | MatchersOrLiterals<Y>) => Mock<Y, T>
+interface CalledWithMock<T, Y extends any[]> extends Mock<FallbackImplementation<Y, T>> {
+  calledWith: (...args: Y | MatchersOrLiterals<Y>) => Mock<FallbackImplementation<Y, T>>
 }
 
 type _MockProxy<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type FallbackImplementation<Y extends any[], T> = (...args: Y) => T


### PR DESCRIPTION
This is my first contribution and I'm not a typescript wizard :D, so feel free to check whether my changes makes sense.

The problem was that Vitest `Mock` receives only one generic argument, but 2 were being provided.
I checked what it were expecting, and it happened to be the exact definition as the `FallbackImplementation` on the project, so I just used it.

Besides that, a test as breaking because it was assuming the host machine would be on the UTC timezone. I fixed it by creating the date using the unix timestamp, not sure if it is a good way. It can also be solved by setting the `TZ` env variable.

This PR closes the issue #508 