### PR TITLE
feat: support calledWith on existing Vitest mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ const fn = mockFn<MyFn>();
 fn.calledWith(1, 2).mockReturnValue('str');
 ```
 
+To add the `calledWith` extension to a function created by Vitest's `vi.mock`, pass the existing mock to `mockFn`. The same Vitest mock is returned, so its call history and standard mock APIs are retained:
+
+```ts
+import { vi } from 'vitest';
+import { mockFn } from 'vitest-mock-extended';
+import { aFunction } from './someThingIWantToMock';
+
+vi.mock('./someThingIWantToMock');
+
+const mockedAFunction = mockFn(aFunction);
+mockedAFunction.calledWith('foobar').mockReturnValue(true);
+```
+
+This decorates an individual, already-imported Vitest mock. It does not mock a module or provide a `mockImportDeep` helper; use Vitest's `vi.mock` (and its factory/hoisting rules) to create the module mock first.
+
 ## Clearing / Resetting Mocks
 
 `vitest-mock-extended` exposes a mockClear and mockReset for resetting or clearing mocks with the same

--- a/src/CalledWithFn.ts
+++ b/src/CalledWithFn.ts
@@ -45,16 +45,31 @@ const checkCalledWith = <T, Y extends any[]>(
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: This is necessary to support any matcher that has an asymmetricMatch function, not just our own Matcher class.
-type CalledWithFnArgs<Y extends any[], T> = { fallbackMockImplementation?: FallbackImplementation<Y, T> }
+type CalledWithFnArgs<Y extends any[], T> = {
+  fallbackMockImplementation?: FallbackImplementation<Y, T>
+  mock?: Mock<CalledWithImplementation<Y, T>>
+}
+
+const decoratedMocks = new WeakMap<object, unknown>()
 
 // biome-ignore lint/suspicious/noExplicitAny: This is necessary to support any matcher that has an asymmetricMatch function, not just our own Matcher class.
 const calledWithFn = <T, Y extends any[]>({
   fallbackMockImplementation,
+  mock: existingMock,
 }: CalledWithFnArgs<Y, T> = {}): CalledWithMock<T, Y> => {
-  const fn: Mock<CalledWithImplementation<Y, T>> = fallbackMockImplementation
-    ? vi.fn(fallbackMockImplementation)
-    : vi.fn()
+  if (existingMock) {
+    const decoratedMock = decoratedMocks.get(existingMock as object)
+    if (decoratedMock) {
+      return decoratedMock as CalledWithMock<T, Y>
+    }
+  }
+
+  const fn: Mock<CalledWithImplementation<Y, T>> =
+    existingMock ?? (fallbackMockImplementation ? vi.fn(fallbackMockImplementation) : vi.fn())
+  const existingMockImplementation = existingMock?.getMockImplementation()
+  const effectiveFallbackMockImplementation = fallbackMockImplementation ?? existingMockImplementation
   let calledWithStack: CalledWithStackItem<T, Y>[] = []
+  let hasCalledWithImplementation = false
 
   ;(fn as CalledWithMock<T, Y>).calledWith = (...args) => {
     // We create new function to delegate any interactions (mockReturnValue etc.) to for this set of args.
@@ -64,20 +79,25 @@ const calledWithFn = <T, Y extends any[]>({
       : vi.fn()
     const mockImplementation = fn.getMockImplementation()
     if (
-      !mockImplementation ||
-      fn.getMockImplementation()?.name === 'implementation' ||
-      mockImplementation === fallbackMockImplementation
+      (existingMock && (!hasCalledWithImplementation || !mockImplementation)) ||
+      (!existingMock &&
+        (!mockImplementation ||
+          fn.getMockImplementation()?.name === 'implementation' ||
+          mockImplementation === fallbackMockImplementation))
     ) {
       // Our original function gets a mock implementation which handles the matching
-      fn.mockImplementation((...args: Y) => checkCalledWith(calledWithStack, args, fallbackMockImplementation))
+      fn.mockImplementation((...args: Y) => checkCalledWith(calledWithStack, args, effectiveFallbackMockImplementation))
       calledWithStack = []
+      hasCalledWithImplementation = true
     }
     calledWithStack.unshift({ args, calledWithFn })
 
     return calledWithFn
   }
 
-  return fn as CalledWithMock<T, Y>
+  const decoratedMock = fn as CalledWithMock<T, Y>
+  decoratedMocks.set(fn, decoratedMock)
+  return decoratedMock
 }
 
 export { calledWithFn }

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -2,7 +2,7 @@ import type { DeepPartial } from 'ts-essentials'
 import { type Mock, vi } from 'vitest'
 import { calledWithFn } from './CalledWithFn'
 import type { MatchersOrLiterals } from './Matchers'
-import type { FallbackImplementation } from './types'
+import type { CalledWithImplementation, FallbackImplementation } from './types'
 
 type ProxiedProperty = string | number | symbol
 
@@ -215,9 +215,15 @@ const mockFn = <
   A extends any[] = T extends (...args: infer AReal) => any ? AReal : any[],
   // biome-ignore lint/suspicious/noExplicitAny: This is necessary to support any matcher that has an asymmetricMatch function, not just our own Matcher class.
   R = T extends (...args: any) => infer RReal ? RReal : any,
->(): CalledWithMock<R, A> & T => {
+>(
+  existingMock?: T
+): CalledWithMock<R, A> & T => {
+  if (existingMock !== undefined && !vi.isMockFunction(existingMock)) {
+    throw new TypeError('mockFn expects a Vitest mock function')
+  }
+
   // @ts-expect-error hard to get this type right using any
-  return calledWithFn()
+  return calledWithFn({ mock: existingMock as Mock<CalledWithImplementation<A, R>> })
 }
 
 const isMockObject = <T>(obj: T): obj is MockProxy<T> => {

--- a/src/ViMock.spec.ts
+++ b/src/ViMock.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest'
+import { aFunction } from '../test/vi-mock-fixture'
+import { mockFn } from './Mock'
+
+vi.mock('../test/vi-mock-fixture')
+
+type AFunction = (value: string) => boolean
+const mockedAFunction = aFunction as Mock<AFunction>
+
+describe('mockFn with an existing Vitest mock', () => {
+  beforeEach(() => {
+    mockedAFunction.mockReset()
+  })
+
+  test('configures argument-specific behavior on a vi.mock function', () => {
+    const existingMock = mockedAFunction
+    const configuredMock = mockFn(existingMock)
+
+    configuredMock.calledWith('foobar').mockReturnValue(true)
+
+    expect(configuredMock).toBe(existingMock)
+    expect(configuredMock('foobar')).toBe(true)
+    expect(configuredMock('other')).toBeUndefined()
+  })
+
+  test('retains Vitest identity, call history, and mock APIs', () => {
+    const existingMock = mockedAFunction
+    const configuredMock = mockFn(existingMock)
+
+    configuredMock.mockName('module function')
+    configuredMock('foobar')
+
+    expect(configuredMock).toBe(existingMock)
+    expect(configuredMock.getMockName()).toBe('module function')
+    expect(existingMock).toHaveBeenCalledWith('foobar')
+    expect(existingMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('reuses the decoration when the same mock is passed twice', () => {
+    const configuredMock = mockFn(mockedAFunction)
+    configuredMock.calledWith('first').mockReturnValue(true)
+
+    const redecoratedMock = mockFn(mockedAFunction)
+    redecoratedMock.calledWith('second').mockReturnValue(true)
+
+    expect(redecoratedMock).toBe(configuredMock)
+    expect(redecoratedMock('first')).toBe(true)
+    expect(redecoratedMock('second')).toBe(true)
+    expect(redecoratedMock('other')).toBeUndefined()
+  })
+
+  test('rejects a non-Vitest function', () => {
+    const realFunction = () => true
+
+    expect(() => mockFn(realFunction)).toThrowError('mockFn expects a Vitest mock function')
+  })
+
+  test('can be configured again after the existing mock is reset', () => {
+    const configuredMock = mockFn(mockedAFunction)
+
+    configuredMock.calledWith('first').mockReturnValue(true)
+    configuredMock.mockReset()
+    configuredMock.calledWith('second').mockReturnValue(true)
+
+    expect(configuredMock('first')).toBeUndefined()
+    expect(configuredMock('second')).toBe(true)
+  })
+})
+
+describe('mockFn type compatibility', () => {
+  test('supports explicitly typed functions without an existing mock', () => {
+    type MyFn = (value: number) => string
+    const configuredMock = mockFn<MyFn>()
+
+    configuredMock.calledWith(1).mockReturnValue('one')
+    const result: string | undefined = configuredMock(1)
+
+    expect(result).toBe('one')
+  })
+
+  test('infers argument and return types from an existing mock', () => {
+    const existingMock = vi.fn((value: number) => value.toString())
+    const configuredMock = mockFn(existingMock)
+
+    configuredMock.calledWith(1).mockReturnValue('one')
+    const result: string | undefined = configuredMock(1)
+
+    expect(result).toBe('one')
+    expect(configuredMock(2)).toBe('2')
+  })
+})

--- a/test/vi-mock-fixture.ts
+++ b/test/vi-mock-fixture.ts
@@ -1,0 +1,1 @@
+export const aFunction = (value: string): boolean => value.length > 0


### PR DESCRIPTION
Add optional existing-mock support to mockFn so vi.mock-created functions can use calledWith while preserving identity and call history.

Resolves #299